### PR TITLE
Make CMake target functions more generic

### DIFF
--- a/CMake/targets.cmake
+++ b/CMake/targets.cmake
@@ -1,31 +1,66 @@
-function(UnitTest NAME)
-  add_executable(${NAME} ${NAME}.cpp)
-  add_test(${NAME} ${NAME})
+macro(parse_arguments)
+  set(options)
+  set(oneValueArgs NAME)
+  set(multiValueArgs SOURCES HEADERS LIBRARIES)
+  cmake_parse_arguments(
+    TARGET
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+endmacro()
+
+function(UnitTest)
+  parse_arguments(${ARGV})
+
+  add_executable(
+    ${TARGET_NAME}
+    ${TARGET_SOURCES}
+  )
+  add_test(${TARGET_NAME} ${TARGET_NAME})
 
   target_include_directories(
-    ${NAME} PUBLIC
-    ${CMAKE_SOURCE_DIR}/src
+    ${TARGET_NAME}
+    PRIVATE
+    ${TARGET_HEADERS}
   )
 
   target_link_libraries(
-    ${NAME}
+    ${TARGET_NAME}
     ${CONAN_LIBS_GTEST}
+    ${TARGET_LIBRARIES}
   )
-endfunction(UnitTest)
+endfunction()
 
-function(Benchmark NAME)
-  add_executable(${NAME} ${NAME}.cpp)
-  add_test(${NAME} ${NAME})
-  add_dependencies(${NAME} benchmark)
+function(Benchmark)
+  parse_arguments(${ARGV})
+
+  add_executable(
+    ${TARGET_NAME}
+    ${TARGET_SOURCES}
+  )
+
+  add_test(
+    ${TARGET_NAME}
+    ${TARGET_NAME}
+  )
+
+  add_dependencies(
+    ${TARGET_NAME}
+    benchmark
+  )
 
   target_include_directories(
-    ${NAME} PUBLIC
-    ${CMAKE_SOURCE_DIR}/src
+    ${TARGET_NAME}
+    PRIVATE
+    ${TARGET_HEADERS}
   )
 
   target_link_libraries(
-    ${NAME}
+    ${TARGET_NAME}
     ${GBENCH_LIBRARIES}
     ${CONAN_LIBS}
+    ${TARGET_LIBRARIES}
   )
-endfunction(Benchmark)
+endfunction()

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,2 +1,12 @@
-Benchmark(BitInterleaving128bitBenchmark)
-Benchmark(BitInterleaving64bitBenchmark)
+set(BENCHMARKS
+  BitInterleaving128bitBenchmark
+  BitInterleaving64bitBenchmark
+)
+
+foreach(BENCHMARK ${BENCHMARKS})
+  Benchmark(
+    NAME ${BENCHMARK}
+    SOURCES ${BENCHMARK}.cpp
+    HEADERS ${CMAKE_SOURCE_DIR}/src
+  )
+endforeach(BENCHMARK)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,15 @@
-UnitTest(MDEventTest)
-UnitTest(BitInterleavingTest)
-UnitTest(BitInterleaving128BitTest)
-UnitTest(BitInterleavingEigenTest)
-UnitTest(TestUtilTest)
+set(UNIT_TESTS
+  BitInterleaving128BitTest
+  BitInterleavingEigenTest
+  BitInterleavingTest
+  MDEventTest
+  TestUtilTest
+)
+
+foreach(TEST ${UNIT_TESTS})
+  UnitTest(
+    NAME ${TEST}
+    SOURCES ${TEST}.cpp
+    HEADERS ${CMAKE_SOURCE_DIR}/src
+  )
+endforeach(TEST)


### PR DESCRIPTION
Allows specifying libraries, headers, etc and multiple source files per target.