### PR TITLE
Make use of CHAR_BIT constant

### DIFF
--- a/src/BitInterleaving128bit.h
+++ b/src/BitInterleaving128bit.h
@@ -1,4 +1,5 @@
 #include <cinttypes>
+#include <climits>
 #include <cstddef>
 
 #include <boost/multiprecision/cpp_int.hpp>
@@ -13,7 +14,7 @@
  */
 void Interleave_4_32_128(uint64_t &msb, uint64_t &lsb, const uint32_t a,
                          const uint32_t b, const uint32_t c, const uint32_t d) {
-  const size_t halfBitLen(sizeof(uint32_t) * 4);
+  const size_t halfBitLen(sizeof(uint32_t) * CHAR_BIT / 2);
 
   lsb = Interleave_4_16_64(a, b, c, d);
   msb = Interleave_4_16_64(a >> halfBitLen, b >> halfBitLen, c >> halfBitLen,
@@ -26,7 +27,7 @@ void Interleave_4_32_128(uint64_t &msb, uint64_t &lsb, const uint32_t a,
  */
 void Deinterleave_4_32_128(const uint64_t msb, const uint64_t lsb, uint32_t &a,
                            uint32_t &b, uint32_t &c, uint32_t &d) {
-  const size_t halfBitLen(sizeof(uint32_t) * 4);
+  const size_t halfBitLen(sizeof(uint32_t) * CHAR_BIT / 2);
 
   uint16_t aa, bb, cc, dd;
 

--- a/src/BitInterleavingEigen.h
+++ b/src/BitInterleavingEigen.h
@@ -1,4 +1,5 @@
 #include <cinttypes>
+#include <climits>
 #include <cstddef>
 
 #include <Eigen/Dense>
@@ -11,7 +12,7 @@ template <typename InterleavedT, typename IntegerT, size_t N>
 InterleavedT Interleave(const Array<IntegerT, N> &data) {
   InterleavedT out(0);
   /* For each bit in the input integer width */
-  for (int i = 0; i < sizeof(IntegerT) * 8; i++) {
+  for (int i = 0; i < sizeof(IntegerT) * CHAR_BIT; i++) {
     /* For each input integer */
     for (int b = 0; b < N; b++) {
       out |=
@@ -36,7 +37,7 @@ Array<IntegerT, N> Deinterleave(const InterleavedT in) {
   Array<IntegerT, N> res;
   res.setZero();
   /* For each bit in the input integer width */
-  for (int i = 0; i < sizeof(IntegerT) * 8; i++) {
+  for (int i = 0; i < sizeof(IntegerT) * CHAR_BIT; i++) {
     /* For each input integer */
     for (int b = 0; b < N; b++) {
       /* Select the bit in the interleaved number, shift it back to the


### PR DESCRIPTION
The `CHAR_BIT` constant defines the number of bits in a byte.

None of the target architectures actually have CHAR_BIT != 8, but it at least removes a magic number.

See http://en.cppreference.com/w/cpp/types/climits