### PR TITLE
Revert to using traditional Conan/CMake integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - mkdir build
   - cd build
 
+  - ../conan_setup.sh .. Release
   - cmake -DCMAKE_BUILD_TYPE=Release ..
   - make -j4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake")
-include(conan)
 
-conan_cmake_run(
-  REQUIRES
-    boost/1.67.0@conan/stable
-    eigen/3.3.4@conan/stable
-    gtest/1.8.0@bincrafters/stable
-  BUILD
-    gtest
-  BASIC_SETUP
-  NO_OUTPUT_DIRS)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(NO_OUTPUT_DIRS)
 
 find_package(Threads REQUIRED)
 include(GoogleBenchmark)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Building requires CMake and [Conan](https://conan.io/).
 
 1. `mkdir build`
 2. `cd build`
-3. `cmake -DCMAKE_BUILD_TYPE=Release /path/to/src/dir`
-   ([cmake-conan](https://github.com/conan-io/cmake-conan) requires
-   `CMAKE_BUILD_TYPE` to be non-empty)
-4. `make`
+3. `./conan_setup.sh /path/to/src/dir/conanfile.txt [Release/Debug]`
+4. `cmake /path/to/src/dir -DCMAKE_BUILD_TYPE=[Release/Debug]`
+5. `make`

--- a/conan_setup.sh
+++ b/conan_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Usage: ./conan_setup.sh [path/to/conanfile.txt] [Release/Debug]
+
+conan install $1 \
+  -s build_type=$2 \
+  -s compiler.libcxx=libstdc++11 \
+  --build gtest

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[generators]
+cmake
+
+[requires]
+boost/1.67.0@conan/stable
+eigen/3.3.4@conan/stable
+gtest/1.8.0@bincrafters/stable


### PR DESCRIPTION
`cmake-conan` extension insisted on rebuilding dependencies that are forced to be built from source every time CMake was run, which while not a bad idea does add a lot of additional time to switching build configuration or modifying CMake targets that need not be an issue.