### PR TITLE
Add loader for NeXus event data

### DIFF
--- a/CMake/targets.cmake
+++ b/CMake/targets.cmake
@@ -79,3 +79,13 @@ function(Executable)
     ${TARGET_LIBRARIES}
   )
 endfunction()
+
+function(Library)
+  parse_arguments(${ARGV})
+
+  add_library(
+    ${TARGET_NAME}
+    SHARED
+    ${TARGET_SOURCES}
+  )
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_subdirectory(benchmark)
 add_subdirectory(exe)
 add_subdirectory(test)
+
+Library(
+  NAME
+    MDSpaceFillingPrototype
+  SOURCES
+    EventNexusLoader.cpp
+)

--- a/src/Event.h
+++ b/src/Event.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct Event {
+  uint32_t id;
+  float tof;
+  double pulse_time;
+};

--- a/src/EventNexusLoader.cpp
+++ b/src/EventNexusLoader.cpp
@@ -1,0 +1,112 @@
+#include "EventNexusLoader.h"
+
+using namespace hdf5;
+
+EventNexusLoader::EventNexusLoader(const std::string &filename,
+                                   const std::string &dataPath)
+    : m_file(file::open(filename, file::AccessFlags::READONLY)) {
+  m_datasetGroup = m_file.root()[dataPath];
+
+  resize_and_read_dataset(m_eventIndex, m_datasetGroup["event_index"]);
+  resize_and_read_dataset(m_eventTimeZero, m_datasetGroup["event_time_zero"]);
+}
+
+size_t EventNexusLoader::totalEventCount() const {
+  node::Dataset dataset = m_datasetGroup["event_id"];
+  const auto space = dataset.dataspace();
+  return space.size();
+}
+
+size_t EventNexusLoader::frameCount() const { return m_eventIndex.size(); }
+
+const std::vector<uint64_t> &EventNexusLoader::eventIndex() const {
+  return m_eventIndex;
+}
+
+const std::vector<double> &EventNexusLoader::eventTimeZero() const {
+  return m_eventTimeZero;
+}
+
+void EventNexusLoader::eventId(std::vector<uint32_t> &data, size_t start,
+                               size_t end) const {
+  resize_and_read_dataset_range(data, m_datasetGroup["event_id"], start, end);
+}
+
+void EventNexusLoader::eventTimeOffset(std::vector<float> &data, size_t start,
+                                       size_t end) const {
+  resize_and_read_dataset_range(data, m_datasetGroup["event_time_offset"],
+                                start, end);
+}
+
+std::pair<size_t, size_t>
+EventNexusLoader::getFrameEventRange(size_t frameIdx) const {
+  const auto start = m_eventIndex[frameIdx];
+  const auto end = frameIdx >= m_eventIndex.size() - 1
+                       ? totalEventCount() - 1
+                       : m_eventIndex[frameIdx + 1];
+
+  return std::make_pair(start, end - start);
+}
+
+void EventNexusLoader::loadFrames(std::vector<Event> &events,
+                                  const std::vector<size_t> &frameIdxs) const {
+  struct FrameParams {
+    size_t nexusEventStart;
+    size_t memoryEventStart;
+    size_t numEvents;
+    double timeZero;
+  };
+
+  /* Calculate total number of events and frame parameters */
+  size_t numEvents = 0;
+  std::vector<FrameParams> frameParams;
+
+  for (const auto &frameIdx : frameIdxs) {
+    /* Get event start and end range for frame */
+    const auto eventRange = getFrameEventRange(frameIdx);
+
+    /* Record frame event ranges */
+    frameParams.push_back({eventRange.first, numEvents, eventRange.second,
+                           m_eventTimeZero[frameIdx]});
+
+    /* Increment total event count */
+    numEvents += eventRange.second;
+  }
+
+  /* Allocate vector of correct size */
+  events.resize(numEvents);
+
+  /* Retrieve datasets */
+  node::Dataset eventIdDataset = m_datasetGroup["event_id"];
+  node::Dataset eventTimeOffsetDataset = m_datasetGroup["event_time_offset"];
+
+  /* Create storage for events to be read */
+  std::vector<uint32_t> eventId;
+  std::vector<float> eventTimeOffset;
+
+  /* Load each frame */
+  for (size_t i = 0; i < frameParams.size(); ++i) {
+    const auto params = frameParams[i];
+
+    /* Obtain iterator to start of memory for this frame */
+    auto eventIt = events.begin();
+    std::advance(eventIt, params.memoryEventStart);
+
+    /* Create slab */
+    const dataspace::Hyperslab slab({params.nexusEventStart},
+                                    {params.numEvents}, {1}, {1});
+
+    /* Resize containers to correct size for this frame */
+    eventId.resize(params.numEvents);
+    eventTimeOffset.resize(params.numEvents);
+
+    /* Read event data */
+    eventIdDataset.read(eventId, slab);
+    eventTimeOffsetDataset.read(eventTimeOffset, slab);
+
+    /* Populate events in output storage */
+    for (size_t i = 0; i < params.numEvents; ++i) {
+      *(eventIt++) = {eventId[i], eventTimeOffset[i], params.timeZero};
+    }
+  }
+}

--- a/src/EventNexusLoader.h
+++ b/src/EventNexusLoader.h
@@ -1,0 +1,50 @@
+#include <string>
+
+#include <h5cpp/hdf5.hpp>
+
+#include "Event.h"
+
+#pragma once
+
+template <typename T>
+void resize_and_read_dataset_range(std::vector<T> &data,
+                                   hdf5::node::Dataset dataset, size_t start,
+                                   size_t end) {
+  hdf5::dataspace::Hyperslab slab({start}, {end - start}, {1}, {1});
+  data.resize(slab.block()[0]);
+  dataset.read(data, slab);
+}
+
+template <typename T>
+void resize_and_read_dataset(std::vector<T> &data,
+                             hdf5::node::Dataset dataset) {
+  data.resize(dataset.dataspace().size());
+  dataset.read(data);
+}
+
+class EventNexusLoader {
+public:
+  EventNexusLoader(const std::string &filename, const std::string &dataPath);
+
+  size_t totalEventCount() const;
+  size_t frameCount() const;
+
+  const std::vector<uint64_t> &eventIndex() const;
+  const std::vector<double> &eventTimeZero() const;
+
+  void eventId(std::vector<uint32_t> &data, size_t start, size_t end) const;
+  void eventTimeOffset(std::vector<float> &data, size_t start,
+                       size_t end) const;
+
+  std::pair<size_t, size_t> getFrameEventRange(size_t frameIdx) const;
+
+  void loadFrames(std::vector<Event> &events,
+                  const std::vector<size_t> &frameIdxs) const;
+
+private:
+  hdf5::file::File m_file;
+  hdf5::node::Group m_datasetGroup;
+
+  std::vector<uint64_t> m_eventIndex;
+  std::vector<double> m_eventTimeZero;
+};

--- a/src/exe/CMakeLists.txt
+++ b/src/exe/CMakeLists.txt
@@ -2,5 +2,12 @@ Executable(
   NAME DatasetGenerator
   SOURCES DatasetGenerator.cpp
   HEADERS ${CMAKE_SOURCE_DIR}/src
-  LIBRARIES ${CONAN_LIBS} ${CMAKE_DL_LIBS}
+  LIBRARIES ${CONAN_LIBS}
+)
+
+Executable(
+  NAME NexusParserDemo
+  SOURCES NexusParserDemo
+  HEADERS ${CMAKE_SOURCE_DIR}/src
+  LIBRARIES ${CONAN_LIBS} MDSpaceFillingPrototype
 )

--- a/src/exe/NexusParserDemo.cpp
+++ b/src/exe/NexusParserDemo.cpp
@@ -1,0 +1,56 @@
+#include <algorithm>
+#include <iostream>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <gflags/gflags.h>
+
+#include "Event.h"
+#include "EventNexusLoader.h"
+
+const std::string AllFrames("all");
+
+DEFINE_string(filename, "testdata.nxs", "NeXus file.");
+DEFINE_string(datasetName, "data", "Name of generated dataset.");
+DEFINE_string(frames, AllFrames, "Frames to load.");
+DEFINE_bool(print, false, "Print output events");
+
+int main(int argc, char **argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  EventNexusLoader loader(FLAGS_filename, FLAGS_datasetName);
+  std::cerr << "Total events in file: " << loader.totalEventCount() << '\n';
+
+  std::vector<size_t> frameIdxs;
+  {
+    if (FLAGS_frames == AllFrames) {
+      frameIdxs.resize(loader.frameCount());
+      std::iota(frameIdxs.begin(), frameIdxs.end(), 0);
+    } else {
+      std::vector<std::string> frameIdxStrings;
+      boost::algorithm::split(frameIdxStrings, FLAGS_frames,
+                              boost::algorithm::is_any_of(","));
+      for (const auto &p : frameIdxStrings) {
+        frameIdxs.push_back(std::stol(p));
+      }
+    }
+  }
+
+  std::cerr << "Frames:";
+  for (const auto &frameIdx : frameIdxs) {
+    std::cerr << ' ' << frameIdx;
+  }
+  std::cerr << '\n';
+
+  std::vector<Event> events;
+  loader.loadFrames(events, frameIdxs);
+
+  std::cerr << "Loaded " << events.size() << " events total.\n";
+
+  if (FLAGS_print) {
+    for (const auto &e : events) {
+      std::cout << e.id << '\t' << e.tof << '\t' << e.pulse_time << '\n';
+    }
+  }
+}


### PR DESCRIPTION
Adds loader based on `h5cpp` and a simple demo application.

Currently only provided as a single threaded implementation (as this is not an area where benchmarking is important).

Tested with a ~3GB WISH event file.