### PR TITLE
Add test and benchmarks for Boost GMP bit interleaving

### DIFF
--- a/CMake/FindGMP.cmake
+++ b/CMake/FindGMP.cmake
@@ -1,0 +1,19 @@
+# Try to find the GMP librairies
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+		# Already in cache, be silent
+		set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h )
+find_library(GMP_LIBRARIES NAMES gmp libgmp )
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
+MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(NO_OUTPUT_DIRS)
 
 find_package(Threads REQUIRED)
+find_package(GMP REQUIRED)
 include(GoogleBenchmark)
 include(OpenMP)
 

--- a/src/BitInterleavingBoostGMP.h
+++ b/src/BitInterleavingBoostGMP.h
@@ -1,0 +1,142 @@
+#include <cinttypes>
+#include <cstddef>
+
+#include <boost/multiprecision/gmp.hpp>
+
+#pragma once
+
+using mpz_int = boost::multiprecision::mpz_int;
+
+/**
+ * Pad an integer with 1 padding bit between integer bits.
+ * Maximum input width is 32 bit.
+ */
+mpz_int Pad1_64(mpz_int x) {
+  x &= 0xffff;
+  x = (x | x << 8) & 0xff00ff;
+  x = (x | x << 4) & 0xf0f0f0f;
+  x = (x | x << 2) & 0x33333333;
+  x = (x | x << 1) & 0x55555555;
+  return x;
+}
+
+/**
+ * Compacts (removes padding) an integer with 1 padding bit between integer
+ * bits.
+ * Maximum output bit width is 32 bit.
+ */
+mpz_int Compact1_64(mpz_int x) {
+  x &= 0x55555555;
+  x = (x | x >> 1) & 0x33333333;
+  x = (x | x >> 2) & 0xf0f0f0f;
+  x = (x | x >> 4) & 0xff00ff;
+  x = (x | x >> 8) & 0xffff;
+  return x;
+}
+
+/**
+ * Pad an integer with 2 padding bits between integer bits.
+ * Maximum input width is 16 bit.
+ */
+mpz_int Pad2_64(mpz_int x) {
+  x &= 0xffff;
+  x = (x | x << 16) & 0xff0000ff;
+  x = (x | x << 8) & 0xf00f00f00f;
+  x = (x | x << 4) & 0xc30c30c30c3;
+  x = (x | x << 2) & 0x249249249249;
+  return x;
+}
+
+/**
+ * Compacts (removes padding) an integer with 3 padding bit between integer
+ * bits.
+ * Maximum output bit width is 16 bit.
+ */
+mpz_int Compact2_64(mpz_int x) {
+  x &= 0x249249249249;
+  x = (x | x >> 2) & 0xc30c30c30c3;
+  x = (x | x >> 4) & 0xf00f00f00f;
+  x = (x | x >> 8) & 0xff0000ff;
+  x = (x | x >> 16) & 0xffff;
+  return x;
+}
+
+/**
+ * Pad an integer with 3 padding bits between integer bits.
+ * Maximum input width is 16 bit.
+ */
+mpz_int Pad3_64(mpz_int x) {
+  x &= 0xffff;
+  x = (x | x << 32) & 0xf800000007ff;
+  x = (x | x << 16) & 0xf80007c0003f;
+  x = (x | x << 8) & 0xc0380700c03807;
+  x = (x | x << 4) & 0x843084308430843;
+  x = (x | x << 2) & 0x909090909090909;
+  x = (x | x << 1) & 0x1111111111111111;
+  return x;
+}
+
+/**
+ * Compacts (removes padding) an integer with 3 padding bit between integer
+ * bits.
+ * Maximum output bit width is 16 bit.
+ */
+mpz_int Compact3_64(mpz_int x) {
+  x &= 0x1111111111111111;
+  x = (x | x >> 1) & 0x909090909090909;
+  x = (x | x >> 2) & 0x843084308430843;
+  x = (x | x >> 4) & 0xc0380700c03807;
+  x = (x | x >> 8) & 0xf80007c0003f;
+  x = (x | x >> 16) & 0xf800000007ff;
+  x = (x | x >> 32) & 0xffff;
+  return x;
+}
+
+/**
+ * Interleaves two 16 bit integers into a single 32 bit integer.
+ */
+mpz_int Interleave_2_16_32(mpz_int a, mpz_int b) {
+  return Pad1_64(a) | (Pad1_64(b) << 1);
+}
+
+/**
+ * Deinterleaves a 32 bit integer into two 16 bit integers.
+ */
+void Deinterleave_2_16_32(mpz_int z, mpz_int &a, mpz_int &b) {
+  a = Compact1_64(z);
+  b = Compact1_64(z >> 1);
+}
+
+/**
+ * Interleaves three 16 bit integers into a single 64 bit integer.
+ */
+mpz_int Interleave_3_16_64(mpz_int a, mpz_int b, mpz_int c) {
+  return Pad2_64(a) | (Pad2_64(b) << 1) | (Pad2_64(c) << 2);
+}
+
+/**
+ * Deinterleaves a 64 bit integer into three 16 bit integers.
+ */
+void Deinterleave_3_16_64(mpz_int z, mpz_int &a, mpz_int &b, mpz_int &c) {
+  a = Compact2_64(z);
+  b = Compact2_64(z >> 1);
+  c = Compact2_64(z >> 2);
+}
+
+/**
+ * Interleaves four 16 bit integers into a single 64 bit integer.
+ */
+mpz_int Interleave_4_16_64(mpz_int a, mpz_int b, mpz_int c, mpz_int d) {
+  return Pad3_64(a) | (Pad3_64(b) << 1) | (Pad3_64(c) << 2) | (Pad3_64(d) << 3);
+}
+
+/**
+ * Deinterleaves a 64 bit integer into four 16 bit integers.
+ */
+void Deinterleave_4_16_64(mpz_int z, mpz_int &a, mpz_int &b, mpz_int &c,
+                          mpz_int &d) {
+  a = Compact3_64(z);
+  b = Compact3_64(z >> 1);
+  c = Compact3_64(z >> 2);
+  d = Compact3_64(z >> 3);
+}

--- a/src/benchmark/BitInterleaving64bitBoostGMPBenchmark.cpp
+++ b/src/benchmark/BitInterleaving64bitBoostGMPBenchmark.cpp
@@ -1,0 +1,50 @@
+#include <benchmark/benchmark.h>
+
+#include <boost/multiprecision/gmp.hpp>
+
+#include "BitInterleavingBoostGMP.h"
+
+static void BM_Interleave_4_16_64_BoostGMP(benchmark::State &state) {
+  mpz_int a, b, c, d;
+  mpz_int res;
+  for (auto _ : state) {
+    res = Interleave_4_16_64(a, b, c, d);
+    benchmark::DoNotOptimize(a);
+    benchmark::DoNotOptimize(b);
+    benchmark::DoNotOptimize(c);
+    benchmark::DoNotOptimize(d);
+    benchmark::DoNotOptimize(res);
+  }
+}
+BENCHMARK(BM_Interleave_4_16_64_BoostGMP);
+
+static void BM_Deinterleave_4_16_64_BoostGMP(benchmark::State &state) {
+  mpz_int a, b, c, d;
+  mpz_int res;
+  for (auto _ : state) {
+    Deinterleave_4_16_64(res, a, b, c, d);
+    benchmark::DoNotOptimize(a);
+    benchmark::DoNotOptimize(b);
+    benchmark::DoNotOptimize(c);
+    benchmark::DoNotOptimize(d);
+    benchmark::DoNotOptimize(res);
+  }
+}
+BENCHMARK(BM_Deinterleave_4_16_64_BoostGMP);
+
+static void BM_RoundTrip_4_16_64_BoostGMP(benchmark::State &state) {
+  mpz_int a, b, c, d;
+  mpz_int res;
+  for (auto _ : state) {
+    res = Interleave_4_16_64(a, b, c, d);
+    Deinterleave_4_16_64(res, a, b, c, d);
+    benchmark::DoNotOptimize(a);
+    benchmark::DoNotOptimize(b);
+    benchmark::DoNotOptimize(c);
+    benchmark::DoNotOptimize(d);
+    benchmark::DoNotOptimize(res);
+  }
+}
+BENCHMARK(BM_RoundTrip_4_16_64_BoostGMP);
+
+BENCHMARK_MAIN();

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(BENCHMARKS
   BitInterleaving128bitBenchmark
   BitInterleaving64bitBenchmark
+  BitInterleaving64bitBoostGMPBenchmark
   CoordinateConversionBenchmark
   EventCreationBenchmark
   SortBenchmark
@@ -13,5 +14,6 @@ foreach(BENCHMARK ${BENCHMARKS})
     NAME ${BENCHMARK}
     SOURCES ${BENCHMARK}.cpp
     HEADERS ${CMAKE_SOURCE_DIR}/src
+    LIBRARIES ${GMP_LIBRARIES}
   )
 endforeach(BENCHMARK)

--- a/src/test/BitInterleavingBoostGMPTest.cpp
+++ b/src/test/BitInterleavingBoostGMPTest.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include <boost/multiprecision/gmp.hpp>
+
+#include "TestUtil.h"
+
+#include "BitInterleavingBoostGMP.h"
+
+using mpz_int = boost::multiprecision::mpz_int;
+
+TEST(BitInterleavingBoostGMPTest, Interleave2) {
+  const mpz_int a = bit_string_to_int<uint8_t>("10101010");
+  const mpz_int b = bit_string_to_int<uint8_t>("00001111");
+
+  const mpz_int res = Interleave_2_16_32(a, b);
+
+  EXPECT_EQ(bit_string_to_int<mpz_int>("0100010011101110"), res);
+}
+
+TEST(BitInterleavingBoostGMPTest, Deinterleave2) {
+  const mpz_int i = bit_string_to_int<mpz_int>("0100010011101110");
+
+  mpz_int a(0), b(0);
+  Deinterleave_2_16_32(i, a, b);
+
+  EXPECT_EQ(bit_string_to_int<uint8_t>("10101010"), a);
+  EXPECT_EQ(bit_string_to_int<uint8_t>("00001111"), b);
+}
+
+TEST(BitInterleavingBoostGMPTest, Interleave3) {
+  const mpz_int a = bit_string_to_int<uint8_t>("10101010");
+  const mpz_int b = bit_string_to_int<uint8_t>("00001111");
+  const mpz_int c = bit_string_to_int<uint8_t>("11110000");
+
+  const mpz_int res = Interleave_3_16_64(a, b, c);
+
+  EXPECT_EQ(bit_string_to_int<mpz_int>("101100101100011010011010"), res);
+}
+
+TEST(BitInterleavingBoostGMPTest, Deinterleave3) {
+  const mpz_int i = bit_string_to_int<mpz_int>("101100101100011010011010");
+
+  mpz_int a(0), b(0), c(0);
+  Deinterleave_3_16_64(i, a, b, c);
+
+  EXPECT_EQ(bit_string_to_int<mpz_int>("10101010"), a);
+  EXPECT_EQ(bit_string_to_int<mpz_int>("00001111"), b);
+  EXPECT_EQ(bit_string_to_int<mpz_int>("11110000"), c);
+}
+
+TEST(BitInterleavingBoostGMPTest, Interleave4) {
+  const mpz_int a = bit_string_to_int<uint8_t>("10101010");
+  const mpz_int b = bit_string_to_int<uint8_t>("00001111");
+  const mpz_int c = bit_string_to_int<uint8_t>("11110000");
+  const mpz_int d = bit_string_to_int<uint8_t>("00111100");
+
+  const mpz_int res = Interleave_4_16_64(a, b, c, d);
+
+  EXPECT_EQ(bit_string_to_int<mpz_int>("01010100110111001011101000110010"),
+            res);
+}
+
+TEST(BitInterleavingBoostGMPTest, Deinterleave4) {
+  const mpz_int i =
+      bit_string_to_int<mpz_int>("01010100110111001011101000110010");
+
+  mpz_int a(0), b(0), c(0), d(0);
+  Deinterleave_4_16_64(i, a, b, c, d);
+
+  EXPECT_EQ(bit_string_to_int<mpz_int>("10101010"), a);
+  EXPECT_EQ(bit_string_to_int<mpz_int>("00001111"), b);
+  EXPECT_EQ(bit_string_to_int<mpz_int>("11110000"), c);
+  EXPECT_EQ(bit_string_to_int<mpz_int>("00111100"), d);
+}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UNIT_TESTS
   BitInterleaving128BitTest
+  BitInterleavingBoostGMPTest
   BitInterleavingEigenTest
   BitInterleavingTest
   CoordinateConversionTest
@@ -13,7 +14,7 @@ foreach(TEST ${UNIT_TESTS})
     NAME ${TEST}
     SOURCES ${TEST}.cpp
     HEADERS ${CMAKE_SOURCE_DIR}/src
-    LIBRARIES ${CONAN_LIBS} MDSpaceFillingPrototype
+    LIBRARIES ${CONAN_LIBS} ${GMP_LIBRARIES} MDSpaceFillingPrototype
   )
 endforeach(TEST)
 


### PR DESCRIPTION
Benchmarks `uint64_t` against Boost's `mpz_int` (which wraps a GMP integer).

See https://www.boost.org/doc/libs/1_67_0/libs/multiprecision/doc/html/boost_multiprecision/tut/ints.html

This is likely not useful given the large overhead of `mpz_int`.

`uint64_t`:

```
2018-07-17 09:09:39
Running ./src/benchmark/BitInterleaving64bitBenchmark
Run on (32 X 3700 MHz CPU s)
CPU Caches:
  L1 Data 32K (x16)
  L1 Instruction 32K (x16)
  L2 Unified 1024K (x16)
  L3 Unified 25344K (x2)
---------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------
BM_Interleave_4_16_64            8 ns          8 ns   92300195
BM_Deinterleave_4_16_64          7 ns          7 ns   99150969
BM_RoundTrip_4_16_64            17 ns         17 ns   40185500
BM_Interleave_Eigen_4           13 ns         13 ns   55820945
BM_Deinterleave_Eigen_4         17 ns         17 ns   40192168
BM_RoundTrip_Eigen_4            30 ns         30 ns   23109010
```

`boost::multiprecision:mpz_int`:

```
2018-07-17 09:09:47
Running ./src/benchmark/BitInterleaving64bitBoostGMPBenchmark
Run on (32 X 3700 MHz CPU s)
CPU Caches:
  L1 Data 32K (x16)
  L1 Instruction 32K (x16)
  L2 Unified 1024K (x16)
  L3 Unified 25344K (x2)
------------------------------------------------------------------------
Benchmark                                 Time           CPU Iterations
------------------------------------------------------------------------
BM_Interleave_4_16_64_BoostGMP         1747 ns       1747 ns     403420
BM_Deinterleave_4_16_64_BoostGMP       1865 ns       1865 ns     374940
BM_RoundTrip_4_16_64_BoostGMP          3802 ns       3802 ns     172312                                                        
```