### PR TITLE
Bit interleaving refactor

### DIFF
--- a/src/BitInterleaving.h
+++ b/src/BitInterleaving.h
@@ -14,6 +14,16 @@ template <size_t N, typename Int> Int compact(Int x) {
 }
 
 /**
+ * Trait used to determine which pad and compact function we can use for a given
+ * Morton number type (defaults to the Morton number type itself).
+ */
+template <typename T> struct morton_to_pad_compact_int { typedef T type; };
+
+template <> struct morton_to_pad_compact_int<uint32_t> {
+  typedef uint64_t type;
+};
+
+/**
  * Pad an integer with 1 padding bit between integer bits.
  * Maximum input width is 32 bit.
  */
@@ -102,7 +112,9 @@ template <size_t ND, typename IntT, typename MortonT>
 MortonT interleave(const IntArray<ND, IntT> &coord) {
   MortonT retVal(0);
   for (size_t i = 0; i < ND; i++) {
-    retVal |= pad<ND - 1, uint64_t>(coord[i]) << i;
+    retVal |=
+        pad<ND - 1, typename morton_to_pad_compact_int<MortonT>::type>(coord[i])
+        << i;
   }
   return retVal;
 }
@@ -111,7 +123,9 @@ template <size_t ND, typename IntT, typename MortonT>
 IntArray<ND, IntT> deinterleave(const MortonT z) {
   IntArray<ND, IntT> retVal;
   for (size_t i = 0; i < ND; i++) {
-    retVal[i] = compact<ND - 1, uint64_t>(z >> i);
+    retVal[i] =
+        compact<ND - 1, typename morton_to_pad_compact_int<MortonT>::type>(z >>
+                                                                           i);
   }
   return retVal;
 }

--- a/src/BitInterleaving.h
+++ b/src/BitInterleaving.h
@@ -3,11 +3,19 @@
 
 #pragma once
 
+template <size_t N, typename Int> Int pad(Int x) {
+  throw std::runtime_error("");
+}
+
+template <size_t N, typename Int> Int compact(Int x) {
+  throw std::runtime_error("");
+}
+
 /**
  * Pad an integer with 1 padding bit between integer bits.
  * Maximum input width is 32 bit.
  */
-uint64_t Pad1_64(uint64_t x) {
+template <> uint64_t pad<1, uint64_t>(uint64_t x) {
   x &= 0xffff;
   x = (x | x << 8) & 0xff00ff;
   x = (x | x << 4) & 0xf0f0f0f;
@@ -21,7 +29,7 @@ uint64_t Pad1_64(uint64_t x) {
  * bits.
  * Maximum output bit width is 32 bit.
  */
-uint64_t Compact1_64(uint64_t x) {
+template <> uint64_t compact<1, uint64_t>(uint64_t x) {
   x &= 0x55555555;
   x = (x | x >> 1) & 0x33333333;
   x = (x | x >> 2) & 0xf0f0f0f;
@@ -34,7 +42,7 @@ uint64_t Compact1_64(uint64_t x) {
  * Pad an integer with 2 padding bits between integer bits.
  * Maximum input width is 16 bit.
  */
-uint64_t Pad2_64(uint64_t x) {
+template <> uint64_t pad<2, uint64_t>(uint64_t x) {
   x &= 0xffff;
   x = (x | x << 16) & 0xff0000ff;
   x = (x | x << 8) & 0xf00f00f00f;
@@ -48,7 +56,7 @@ uint64_t Pad2_64(uint64_t x) {
  * bits.
  * Maximum output bit width is 16 bit.
  */
-uint64_t Compact2_64(uint64_t x) {
+template <> uint64_t compact<2, uint64_t>(uint64_t x) {
   x &= 0x249249249249;
   x = (x | x >> 2) & 0xc30c30c30c3;
   x = (x | x >> 4) & 0xf00f00f00f;
@@ -61,7 +69,7 @@ uint64_t Compact2_64(uint64_t x) {
  * Pad an integer with 3 padding bits between integer bits.
  * Maximum input width is 16 bit.
  */
-uint64_t Pad3_64(uint64_t x) {
+template <> uint64_t pad<3, uint64_t>(uint64_t x) {
   x &= 0xffff;
   x = (x | x << 32) & 0xf800000007ff;
   x = (x | x << 16) & 0xf80007c0003f;
@@ -77,7 +85,7 @@ uint64_t Pad3_64(uint64_t x) {
  * bits.
  * Maximum output bit width is 16 bit.
  */
-uint64_t Compact3_64(uint64_t x) {
+template <> uint64_t compact<3, uint64_t>(uint64_t x) {
   x &= 0x1111111111111111;
   x = (x | x >> 1) & 0x909090909090909;
   x = (x | x >> 2) & 0x843084308430843;
@@ -92,38 +100,43 @@ uint64_t Compact3_64(uint64_t x) {
  * Interleaves two 16 bit integers into a single 32 bit integer.
  */
 uint32_t Interleave_2_16_32(uint32_t a, uint32_t b) {
-  return Pad1_64(a) | (Pad1_64(b) << 1);
+  const auto padFunc = pad<1, uint64_t>;
+  return padFunc(a) | (padFunc(b) << 1);
 }
 
 /**
  * Deinterleaves a 32 bit integer into two 16 bit integers.
  */
 void Deinterleave_2_16_32(uint32_t z, uint16_t &a, uint16_t &b) {
-  a = Compact1_64(z);
-  b = Compact1_64(z >> 1);
+  const auto compactFunc = compact<1, uint64_t>;
+  a = compactFunc(z);
+  b = compactFunc(z >> 1);
 }
 
 /**
  * Interleaves three 16 bit integers into a single 64 bit integer.
  */
 uint64_t Interleave_3_16_64(uint64_t a, uint64_t b, uint64_t c) {
-  return Pad2_64(a) | (Pad2_64(b) << 1) | (Pad2_64(c) << 2);
+  const auto padFunc = pad<2, uint64_t>;
+  return padFunc(a) | (padFunc(b) << 1) | (padFunc(c) << 2);
 }
 
 /**
  * Deinterleaves a 64 bit integer into three 16 bit integers.
  */
 void Deinterleave_3_16_64(uint64_t z, uint16_t &a, uint16_t &b, uint16_t &c) {
-  a = Compact2_64(z);
-  b = Compact2_64(z >> 1);
-  c = Compact2_64(z >> 2);
+  const auto compactFunc = compact<2, uint64_t>;
+  a = compactFunc(z);
+  b = compactFunc(z >> 1);
+  c = compactFunc(z >> 2);
 }
 
 /**
  * Interleaves four 16 bit integers into a single 64 bit integer.
  */
 uint64_t Interleave_4_16_64(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
-  return Pad3_64(a) | (Pad3_64(b) << 1) | (Pad3_64(c) << 2) | (Pad3_64(d) << 3);
+  const auto padFunc = pad<3, uint64_t>;
+  return padFunc(a) | (padFunc(b) << 1) | (padFunc(c) << 2) | (padFunc(d) << 3);
 }
 
 /**
@@ -131,8 +144,9 @@ uint64_t Interleave_4_16_64(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
  */
 void Deinterleave_4_16_64(uint64_t z, uint16_t &a, uint16_t &b, uint16_t &c,
                           uint16_t &d) {
-  a = Compact3_64(z);
-  b = Compact3_64(z >> 1);
-  c = Compact3_64(z >> 2);
-  d = Compact3_64(z >> 3);
+  const auto compactFunc = compact<3, uint64_t>;
+  a = compactFunc(z);
+  b = compactFunc(z >> 1);
+  c = compactFunc(z >> 2);
+  d = compactFunc(z >> 3);
 }

--- a/src/BitInterleaving.h
+++ b/src/BitInterleaving.h
@@ -1,14 +1,16 @@
 #include <cinttypes>
 #include <cstddef>
 
+#include "Types.h"
+
 #pragma once
 
 template <size_t N, typename Int> Int pad(Int x) {
-  throw std::runtime_error("");
+  throw std::runtime_error("No pad() specialisation.");
 }
 
 template <size_t N, typename Int> Int compact(Int x) {
-  throw std::runtime_error("");
+  throw std::runtime_error("No compact() specialisation.");
 }
 
 /**
@@ -96,57 +98,20 @@ template <> uint64_t compact<3, uint64_t>(uint64_t x) {
   return x;
 }
 
-/**
- * Interleaves two 16 bit integers into a single 32 bit integer.
- */
-uint32_t Interleave_2_16_32(uint32_t a, uint32_t b) {
-  const auto padFunc = pad<1, uint64_t>;
-  return padFunc(a) | (padFunc(b) << 1);
+template <size_t ND, typename IntT, typename MortonT>
+MortonT interleave(const IntArray<ND, IntT> &coord) {
+  MortonT retVal(0);
+  for (size_t i = 0; i < ND; i++) {
+    retVal |= pad<ND - 1, uint64_t>(coord[i]) << i;
+  }
+  return retVal;
 }
 
-/**
- * Deinterleaves a 32 bit integer into two 16 bit integers.
- */
-void Deinterleave_2_16_32(uint32_t z, uint16_t &a, uint16_t &b) {
-  const auto compactFunc = compact<1, uint64_t>;
-  a = compactFunc(z);
-  b = compactFunc(z >> 1);
-}
-
-/**
- * Interleaves three 16 bit integers into a single 64 bit integer.
- */
-uint64_t Interleave_3_16_64(uint64_t a, uint64_t b, uint64_t c) {
-  const auto padFunc = pad<2, uint64_t>;
-  return padFunc(a) | (padFunc(b) << 1) | (padFunc(c) << 2);
-}
-
-/**
- * Deinterleaves a 64 bit integer into three 16 bit integers.
- */
-void Deinterleave_3_16_64(uint64_t z, uint16_t &a, uint16_t &b, uint16_t &c) {
-  const auto compactFunc = compact<2, uint64_t>;
-  a = compactFunc(z);
-  b = compactFunc(z >> 1);
-  c = compactFunc(z >> 2);
-}
-
-/**
- * Interleaves four 16 bit integers into a single 64 bit integer.
- */
-uint64_t Interleave_4_16_64(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
-  const auto padFunc = pad<3, uint64_t>;
-  return padFunc(a) | (padFunc(b) << 1) | (padFunc(c) << 2) | (padFunc(d) << 3);
-}
-
-/**
- * Deinterleaves a 64 bit integer into four 16 bit integers.
- */
-void Deinterleave_4_16_64(uint64_t z, uint16_t &a, uint16_t &b, uint16_t &c,
-                          uint16_t &d) {
-  const auto compactFunc = compact<3, uint64_t>;
-  a = compactFunc(z);
-  b = compactFunc(z >> 1);
-  c = compactFunc(z >> 2);
-  d = compactFunc(z >> 3);
+template <size_t ND, typename IntT, typename MortonT>
+IntArray<ND, IntT> deinterleave(const MortonT z) {
+  IntArray<ND, IntT> retVal;
+  for (size_t i = 0; i < ND; i++) {
+    retVal[i] = compact<ND - 1, uint64_t>(z >> i);
+  }
+  return retVal;
 }

--- a/src/BitInterleaving128bit.h
+++ b/src/BitInterleaving128bit.h
@@ -16,9 +16,12 @@ void Interleave_4_32_128(uint64_t &msb, uint64_t &lsb, const uint32_t a,
                          const uint32_t b, const uint32_t c, const uint32_t d) {
   const size_t halfBitLen(sizeof(uint32_t) * CHAR_BIT / 2);
 
-  lsb = Interleave_4_16_64(a, b, c, d);
-  msb = Interleave_4_16_64(a >> halfBitLen, b >> halfBitLen, c >> halfBitLen,
-                           d >> halfBitLen);
+  lsb = interleave<4, uint16_t, uint64_t>(
+      {(uint16_t)a, (uint16_t)b, (uint16_t)c, (uint16_t)d});
+
+  msb = interleave<4, uint16_t, uint64_t>(
+      {(uint16_t)(a >> halfBitLen), (uint16_t)(b >> halfBitLen),
+       (uint16_t)(c >> halfBitLen), (uint16_t)(d >> halfBitLen)});
 }
 
 /**
@@ -29,19 +32,13 @@ void Deinterleave_4_32_128(const uint64_t msb, const uint64_t lsb, uint32_t &a,
                            uint32_t &b, uint32_t &c, uint32_t &d) {
   const size_t halfBitLen(sizeof(uint32_t) * CHAR_BIT / 2);
 
-  uint16_t aa, bb, cc, dd;
+  const auto coordLsb = deinterleave<4, uint16_t, uint64_t>(lsb);
+  const auto coordMsb = deinterleave<4, uint16_t, uint64_t>(msb);
 
-  Deinterleave_4_16_64(lsb, aa, bb, cc, dd);
-  a = aa;
-  b = bb;
-  c = cc;
-  d = dd;
-
-  Deinterleave_4_16_64(msb, aa, bb, cc, dd);
-  a |= aa << halfBitLen;
-  b |= bb << halfBitLen;
-  c |= cc << halfBitLen;
-  d |= dd << halfBitLen;
+  a = coordLsb[0] | (coordMsb[0] << halfBitLen);
+  b = coordLsb[1] | (coordMsb[1] << halfBitLen);
+  c = coordLsb[2] | (coordMsb[2] << halfBitLen);
+  d = coordLsb[3] | (coordMsb[3] << halfBitLen);
 }
 
 using uint128_t = boost::multiprecision::uint128_t;

--- a/src/BitInterleaving128bit.h
+++ b/src/BitInterleaving128bit.h
@@ -2,8 +2,6 @@
 #include <climits>
 #include <cstddef>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include "BitInterleaving.h"
 
 #pragma once
@@ -39,61 +37,4 @@ void Deinterleave_4_32_128(const uint64_t msb, const uint64_t lsb, uint32_t &a,
   b = coordLsb[1] | (coordMsb[1] << halfBitLen);
   c = coordLsb[2] | (coordMsb[2] << halfBitLen);
   d = coordLsb[3] | (coordMsb[3] << halfBitLen);
-}
-
-using uint128_t = boost::multiprecision::uint128_t;
-
-/**
- * Pad an integer with 3 padding bits between integer bits.
- * Maximum input width is 32 bit.
- */
-uint128_t Pad3_128(uint128_t x) {
-  using namespace boost::multiprecision::literals;
-  x &= 0xffffffff_cppui128;
-  x = (x | x << 64) & 0xffc0000000000000003fffff_cppui128;
-  x = (x | x << 32) & 0xffc00000003ff800000007ff_cppui128;
-  x = (x | x << 16) & 0xf80007c0003f0000f80007c0003f_cppui128;
-  x = (x | x << 8) & 0xc0380700c0380700c0380700c03807_cppui128;
-  x = (x | x << 4) & 0x8430843084308430843084308430843_cppui128;
-  x = (x | x << 2) & 0x9090909090909090909090909090909_cppui128;
-  x = (x | x << 1) & 0x11111111111111111111111111111111_cppui128;
-  return x;
-}
-
-/**
- * Compacts (removes padding) an integer with 3 padding bits between integer
- * bits.
- * Maximum output bit width is 32 bit.
- */
-uint128_t Compact3_128(uint128_t x) {
-  using namespace boost::multiprecision::literals;
-  x &= 0x11111111111111111111111111111111_cppui128;
-  x = (x | x >> 1) & 0x9090909090909090909090909090909_cppui128;
-  x = (x | x >> 2) & 0x8430843084308430843084308430843_cppui128;
-  x = (x | x >> 4) & 0xc0380700c0380700c0380700c03807_cppui128;
-  x = (x | x >> 8) & 0xf80007c0003f0000f80007c0003f_cppui128;
-  x = (x | x >> 16) & 0xffc00000003ff800000007ff_cppui128;
-  x = (x | x >> 32) & 0xffc0000000000000003fffff_cppui128;
-  x = (x | x >> 64) & 0xffffffff_cppui128;
-  return x;
-}
-
-/**
- * Interleaves four 32 bit integers into a single 128 bit integer.
- */
-uint128_t Interleave_4_32_128(uint128_t a, uint128_t b, uint128_t c,
-                              uint128_t d) {
-  return Pad3_128(a) | (Pad3_128(b) << 1) | (Pad3_128(c) << 2) |
-         (Pad3_128(d) << 3);
-}
-
-/**
- * Deinterleaves a 128 bit integer into four 32 bit integers.
- */
-void Deinterleave_4_32_128(uint128_t z, uint32_t &a, uint32_t &b, uint32_t &c,
-                           uint32_t &d) {
-  a = (uint32_t)Compact3_128(z);
-  b = (uint32_t)Compact3_128(z >> 1);
-  c = (uint32_t)Compact3_128(z >> 2);
-  d = (uint32_t)Compact3_128(z >> 3);
 }

--- a/src/BitInterleavingEigen.h
+++ b/src/BitInterleavingEigen.h
@@ -2,23 +2,21 @@
 #include <climits>
 #include <cstddef>
 
-#include <Eigen/Dense>
+#include "Types.h"
 
 #pragma once
 
-template <typename T, size_t N> using Array = Eigen::Array<T, N, 1>;
-
-template <typename InterleavedT, typename IntegerT, size_t N>
-InterleavedT Interleave(const Array<IntegerT, N> &data) {
+template <typename InterleavedT, typename IntT, size_t N>
+InterleavedT Interleave(const IntArray<N, IntT> &data) {
   InterleavedT out(0);
   /* For each bit in the input integer width */
-  for (int i = 0; i < sizeof(IntegerT) * CHAR_BIT; i++) {
+  for (int i = 0; i < sizeof(IntT) * CHAR_BIT; i++) {
     /* For each input integer */
     for (int b = 0; b < N; b++) {
       out |=
           /* Select the bit in the input integer we are interested in, the
            * result of this is either an integer with bit b being set or 0 */
-          (data[b] & ((IntegerT)1 << i))
+          (data[b] & ((IntT)1 << i))
           /* Offset for the correct amount of padding, minus 1 input integer
            * width (as the bit will already be in shifted for one integer width)
            */
@@ -32,19 +30,19 @@ InterleavedT Interleave(const Array<IntegerT, N> &data) {
   return out;
 }
 
-template <typename InterleavedT, typename IntegerT, size_t N>
-Array<IntegerT, N> Deinterleave(const InterleavedT in) {
-  Array<IntegerT, N> res;
+template <typename InterleavedT, typename IntT, size_t N>
+IntArray<N, IntT> Deinterleave(const InterleavedT in) {
+  IntArray<N, IntT> res;
   res.setZero();
   /* For each bit in the input integer width */
-  for (int i = 0; i < sizeof(IntegerT) * CHAR_BIT; i++) {
+  for (int i = 0; i < sizeof(IntT) * CHAR_BIT; i++) {
     /* For each input integer */
     for (int b = 0; b < N; b++) {
       /* Select the bit in the interleaved number, shift it back to the
        * appropriate position in the result coordinate integer (this is
        * essentially the opposite of what happens in Interleave()) */
-      res[b] |= (IntegerT)((in & (InterleavedT)1 << ((i * N) + b)) >>
-                           ((i * (N - 1)) + b));
+      res[b] |= (IntT)((in & (InterleavedT)1 << ((i * N) + b)) >>
+                       ((i * (N - 1)) + b));
     }
   }
   return res;

--- a/src/MDEvent.h
+++ b/src/MDEvent.h
@@ -16,8 +16,7 @@ public:
       : m_signal(signal) {
     const auto intCoord =
         ConvertCoordinatesToIntegerRange<ND, uint16_t>(space, coord);
-    m_spaceFillingCurveOrder =
-        Interleave_4_16_64(intCoord[0], intCoord[1], intCoord[2], intCoord[3]);
+    m_spaceFillingCurveOrder = interleave<ND, uint16_t, uint64_t>(intCoord);
   }
 
   uint64_t spaceFillingCurveOrder() const { return m_spaceFillingCurveOrder; }

--- a/src/Types.h
+++ b/src/Types.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+template <size_t ND, typename IntT> using IntArray = Eigen::Array<IntT, ND, 1>;
+
 template <size_t ND> using MDCoordinate = Eigen::Array<float, ND, 1>;
 template <size_t ND> using MDSpaceBounds = Eigen::Array<float, ND, 2>;
 template <size_t ND> using MDSpaceSteps = Eigen::Array<float, ND, 1>;

--- a/src/benchmark/BitInterleaving128bitBenchmark.cpp
+++ b/src/benchmark/BitInterleaving128bitBenchmark.cpp
@@ -49,43 +49,34 @@ static void BM_RoundTrip_4_32_128(benchmark::State &state) {
 BENCHMARK(BM_RoundTrip_4_32_128);
 
 static void BM_Interleave_4_32_128_Boost(benchmark::State &state) {
-  uint32_t a, b, c, d;
+  IntArray<4, uint32_t> data;
   uint128_t z;
   for (auto _ : state) {
-    z = Interleave_4_32_128(a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    z = interleave<4, uint32_t, uint128_t>(data);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(z);
   }
 }
 BENCHMARK(BM_Interleave_4_32_128_Boost);
 
 static void BM_Deinterleave_4_32_128_Boost(benchmark::State &state) {
-  uint32_t a, b, c, d;
+  IntArray<4, uint32_t> data;
   uint128_t z;
   for (auto _ : state) {
-    Deinterleave_4_32_128(z, a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    data = deinterleave<4, uint32_t, uint128_t>(z);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(z);
   }
 }
 BENCHMARK(BM_Deinterleave_4_32_128_Boost);
 
 static void BM_RoundTrip_4_32_128_Boost(benchmark::State &state) {
-  uint32_t a, b, c, d;
+  IntArray<4, uint32_t> data;
   uint128_t z;
   for (auto _ : state) {
-    z = Interleave_4_32_128(a, b, c, d);
-    Deinterleave_4_32_128(z, a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    z = interleave<4, uint32_t, uint128_t>(data);
+    data = deinterleave<4, uint32_t, uint128_t>(z);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(z);
   }
 }

--- a/src/benchmark/BitInterleaving64bitBenchmark.cpp
+++ b/src/benchmark/BitInterleaving64bitBenchmark.cpp
@@ -4,50 +4,41 @@
 #include "BitInterleavingEigen.h"
 
 static void BM_Interleave_4_16_64(benchmark::State &state) {
-  uint16_t a, b, c, d;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
-    res = Interleave_4_16_64(a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    res = interleave<4, uint16_t, uint64_t>(data);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(res);
   }
 }
 BENCHMARK(BM_Interleave_4_16_64);
 
 static void BM_Deinterleave_4_16_64(benchmark::State &state) {
-  uint16_t a, b, c, d;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
-    Deinterleave_4_16_64(res, a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    data = deinterleave<4, uint16_t, uint64_t>(res);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(res);
   }
 }
 BENCHMARK(BM_Deinterleave_4_16_64);
 
 static void BM_RoundTrip_4_16_64(benchmark::State &state) {
-  uint16_t a, b, c, d;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
-    res = Interleave_4_16_64(a, b, c, d);
-    Deinterleave_4_16_64(res, a, b, c, d);
-    benchmark::DoNotOptimize(a);
-    benchmark::DoNotOptimize(b);
-    benchmark::DoNotOptimize(c);
-    benchmark::DoNotOptimize(d);
+    res = interleave<4, uint16_t, uint64_t>(data);
+    data = deinterleave<4, uint16_t, uint64_t>(res);
+    benchmark::DoNotOptimize(data);
     benchmark::DoNotOptimize(res);
   }
 }
 BENCHMARK(BM_RoundTrip_4_16_64);
 
 static void BM_Interleave_Eigen_4(benchmark::State &state) {
-  Eigen::Array<uint16_t, 4, 1> data;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
     res = Interleave<uint64_t, uint16_t, 4>(data);
@@ -58,7 +49,7 @@ static void BM_Interleave_Eigen_4(benchmark::State &state) {
 BENCHMARK(BM_Interleave_Eigen_4);
 
 static void BM_Deinterleave_Eigen_4(benchmark::State &state) {
-  Eigen::Array<uint16_t, 4, 1> data;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
     data = Deinterleave<uint64_t, uint16_t, 4>(res);
@@ -69,7 +60,7 @@ static void BM_Deinterleave_Eigen_4(benchmark::State &state) {
 BENCHMARK(BM_Deinterleave_Eigen_4);
 
 static void BM_RoundTrip_Eigen_4(benchmark::State &state) {
-  Eigen::Array<uint16_t, 4, 1> data;
+  IntArray<4, uint16_t> data;
   uint64_t res;
   for (auto _ : state) {
     res = Interleave<uint64_t, uint16_t, 4>(data);

--- a/src/test/BitInterleaving128BitTest.cpp
+++ b/src/test/BitInterleaving128BitTest.cpp
@@ -4,6 +4,7 @@
 
 #include "TestUtil.h"
 
+#include "BitInterleaving.h"
 #include "BitInterleaving128bit.h"
 
 TEST(BitInterleaving128BitTest, Interleave_4_32_128) {
@@ -69,7 +70,7 @@ TEST(BitInterleaving128BitTest, Interleave_4_32_128_Boost) {
   const uint32_t d =
       bit_string_to_int<uint32_t>("00000000111111111111111100000000");
 
-  uint128_t res = Interleave_4_32_128(a, b, c, d);
+  uint128_t res = interleave<4, uint32_t, uint128_t>({a, b, c, d});
 
   uint128_t expected(lsb);
   expected |= msb << 64;
@@ -86,8 +87,7 @@ TEST(BitInterleaving128BitTest, Deinterleave_4_32_128_Boost) {
   uint128_t z(lsb);
   z |= msb << 64;
 
-  uint32_t a(0), b(0), c(0), d(0);
-  Deinterleave_4_32_128(z, a, b, c, d);
+  const auto result = deinterleave<4, uint32_t, uint128_t>(z);
 
   const uint32_t expectedA =
       bit_string_to_int<uint32_t>("10101010101010101010101010101010");
@@ -98,8 +98,8 @@ TEST(BitInterleaving128BitTest, Deinterleave_4_32_128_Boost) {
   const uint32_t expectedD =
       bit_string_to_int<uint32_t>("00000000111111111111111100000000");
 
-  EXPECT_EQ(expectedA, a);
-  EXPECT_EQ(expectedB, b);
-  EXPECT_EQ(expectedC, c);
-  EXPECT_EQ(expectedD, d);
+  EXPECT_EQ(expectedA, result[0]);
+  EXPECT_EQ(expectedB, result[1]);
+  EXPECT_EQ(expectedC, result[2]);
+  EXPECT_EQ(expectedD, result[3]);
 }

--- a/src/test/BitInterleavingEigenTest.cpp
+++ b/src/test/BitInterleavingEigenTest.cpp
@@ -5,9 +5,10 @@
 #include "TestUtil.h"
 
 #include "BitInterleavingEigen.h"
+#include "Types.h"
 
 TEST(BitInterleavingEigenTest, Interleave2) {
-  Array<uint8_t, 2> a;
+  IntArray<2, uint8_t> a;
   // clang-format off
   a << bit_string_to_int<uint8_t>("10101010"),
        bit_string_to_int<uint8_t>("00001111");
@@ -28,7 +29,7 @@ TEST(BitInterleavingEigenTest, Deinterleave2) {
 }
 
 TEST(BitInterleavingEigenTest, Interleave3) {
-  Array<uint8_t, 3> a;
+  IntArray<3, uint8_t> a;
   // clang-format off
   a << bit_string_to_int<uint8_t>("10101010"),
        bit_string_to_int<uint8_t>("00001111"),
@@ -51,7 +52,7 @@ TEST(BitInterleavingEigenTest, Deinterleave3) {
 }
 
 TEST(BitInterleavingEigenTest, Interleave4) {
-  Array<uint8_t, 4> a;
+  IntArray<4, uint8_t> a;
   // clang-format off
   a << bit_string_to_int<uint8_t>("10101010"),
        bit_string_to_int<uint8_t>("00001111"),

--- a/src/test/BitInterleavingTest.cpp
+++ b/src/test/BitInterleavingTest.cpp
@@ -10,7 +10,7 @@ TEST(BitInterleavingTest, Interleave2) {
   const uint16_t a = bit_string_to_int<uint8_t>("10101010");
   const uint16_t b = bit_string_to_int<uint8_t>("00001111");
 
-  const uint32_t res = Interleave_2_16_32(a, b);
+  const uint32_t res = interleave<2, uint16_t, uint32_t>({a, b});
 
   EXPECT_EQ(bit_string_to_int<uint32_t>("0100010011101110"), res);
 }
@@ -18,11 +18,10 @@ TEST(BitInterleavingTest, Interleave2) {
 TEST(BitInterleavingTest, Deinterleave2) {
   const uint32_t i = bit_string_to_int<uint32_t>("0100010011101110");
 
-  uint16_t a(0), b(0);
-  Deinterleave_2_16_32(i, a, b);
+  const auto result = deinterleave<2, uint16_t, uint32_t>(i);
 
-  EXPECT_EQ(bit_string_to_int<uint8_t>("10101010"), a);
-  EXPECT_EQ(bit_string_to_int<uint8_t>("00001111"), b);
+  EXPECT_EQ(bit_string_to_int<uint8_t>("10101010"), result[0]);
+  EXPECT_EQ(bit_string_to_int<uint8_t>("00001111"), result[1]);
 }
 
 TEST(BitInterleavingTest, Interleave3) {
@@ -30,7 +29,7 @@ TEST(BitInterleavingTest, Interleave3) {
   const uint16_t b = bit_string_to_int<uint8_t>("00001111");
   const uint16_t c = bit_string_to_int<uint8_t>("11110000");
 
-  const uint64_t res = Interleave_3_16_64(a, b, c);
+  const uint64_t res = interleave<3, uint16_t, uint64_t>({a, b, c});
 
   EXPECT_EQ(bit_string_to_int<uint32_t>("101100101100011010011010"), res);
 }
@@ -38,12 +37,11 @@ TEST(BitInterleavingTest, Interleave3) {
 TEST(BitInterleavingTest, Deinterleave3) {
   const uint32_t i = bit_string_to_int<uint32_t>("101100101100011010011010");
 
-  uint16_t a(0), b(0), c(0);
-  Deinterleave_3_16_64(i, a, b, c);
+  const auto result = deinterleave<3, uint16_t, uint64_t>(i);
 
-  EXPECT_EQ(bit_string_to_int<uint16_t>("10101010"), a);
-  EXPECT_EQ(bit_string_to_int<uint16_t>("00001111"), b);
-  EXPECT_EQ(bit_string_to_int<uint16_t>("11110000"), c);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("10101010"), result[0]);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("00001111"), result[1]);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("11110000"), result[2]);
 }
 
 TEST(BitInterleavingTest, Interleave4) {
@@ -52,7 +50,7 @@ TEST(BitInterleavingTest, Interleave4) {
   const uint16_t c = bit_string_to_int<uint8_t>("11110000");
   const uint16_t d = bit_string_to_int<uint8_t>("00111100");
 
-  const uint64_t res = Interleave_4_16_64(a, b, c, d);
+  const uint64_t res = interleave<4, uint16_t, uint64_t>({a, b, c, d});
 
   EXPECT_EQ(bit_string_to_int<uint32_t>("01010100110111001011101000110010"),
             res);
@@ -62,11 +60,10 @@ TEST(BitInterleavingTest, Deinterleave4) {
   const uint64_t i =
       bit_string_to_int<uint32_t>("01010100110111001011101000110010");
 
-  uint16_t a(0), b(0), c(0), d(0);
-  Deinterleave_4_16_64(i, a, b, c, d);
+  const auto result = deinterleave<4, uint16_t, uint64_t>(i);
 
-  EXPECT_EQ(bit_string_to_int<uint16_t>("10101010"), a);
-  EXPECT_EQ(bit_string_to_int<uint16_t>("00001111"), b);
-  EXPECT_EQ(bit_string_to_int<uint16_t>("11110000"), c);
-  EXPECT_EQ(bit_string_to_int<uint16_t>("00111100"), d);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("10101010"), result[0]);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("00001111"), result[1]);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("11110000"), result[2]);
+  EXPECT_EQ(bit_string_to_int<uint16_t>("00111100"), result[3]);
 }


### PR DESCRIPTION
Restructures some of the bit interleaving code to make it more generic than the explicit functions.

- Padding and compacting functions are now functions with template specializations
- Generic (at least more generic then the previous implementation) interleaving and deinterleaving
- Integrate Boost cppint 128bit interleave and deinterleave to generic functions
- Changes have little effect on benchmarks (see `BitInterleaving64bitBenchmark`)