### PR TITLE
256bit integer interleaving 

### DIFF
--- a/docs/bit_padding_generator.py
+++ b/docs/bit_padding_generator.py
@@ -38,6 +38,7 @@ def generate_bit_spacing_code(bit_count, empty_bit_count):
 
     return code_str
 
+
 print(generate_bit_spacing_code(8, 1))
 
 print(generate_bit_spacing_code(16, 1))
@@ -47,3 +48,5 @@ print(generate_bit_spacing_code(16, 3))
 print(generate_bit_spacing_code(32, 1))
 print(generate_bit_spacing_code(32, 2))
 print(generate_bit_spacing_code(32, 3))
+
+print(generate_bit_spacing_code(64, 3))

--- a/src/BitInterleaving.h
+++ b/src/BitInterleaving.h
@@ -193,6 +193,53 @@ template <> uint32_t compact<3, uint32_t, uint128_t>(uint128_t x) {
   return (uint32_t)x;
 }
 
+using uint256_t = boost::multiprecision::uint256_t;
+
+template <> uint256_t pad<3, uint64_t, uint256_t>(uint64_t v) {
+  using namespace boost::multiprecision::literals;
+  uint256_t x(v);
+  x &= 0xffffffffffffffff_cppui256;
+  x = (x | x << 128) &
+      0xfffff800000000000000000000000000000007ffffffffff_cppui256;
+  x = (x | x << 64) &
+      0xfffff80000000000000007ffffc0000000000000003fffff_cppui256;
+  x = (x | x << 32) &
+      0xffc00000003ff800000007ff00000000ffc00000003ff800000007ff_cppui256;
+  x = (x | x << 16) &
+      0xf80007c0003f0000f80007c0003f0000f80007c0003f0000f80007c0003f_cppui256;
+  x = (x | x << 8) &
+      0xc0380700c0380700c0380700c0380700c0380700c0380700c0380700c03807_cppui256;
+  x = (x | x << 4) &
+      0x843084308430843084308430843084308430843084308430843084308430843_cppui256;
+  x = (x | x << 2) &
+      0x909090909090909090909090909090909090909090909090909090909090909_cppui256;
+  x = (x | x << 1) &
+      0x1111111111111111111111111111111111111111111111111111111111111111_cppui256;
+  return x;
+}
+
+template <> uint64_t compact<3, uint64_t, uint256_t>(uint256_t x) {
+  using namespace boost::multiprecision::literals;
+  x &=
+      0x1111111111111111111111111111111111111111111111111111111111111111_cppui256;
+  x = (x | x >> 1) &
+      0x909090909090909090909090909090909090909090909090909090909090909_cppui256;
+  x = (x | x >> 2) &
+      0x843084308430843084308430843084308430843084308430843084308430843_cppui256;
+  x = (x | x >> 4) &
+      0xc0380700c0380700c0380700c0380700c0380700c0380700c0380700c03807_cppui256;
+  x = (x | x >> 8) &
+      0xf80007c0003f0000f80007c0003f0000f80007c0003f0000f80007c0003f_cppui256;
+  x = (x | x >> 16) &
+      0xffc00000003ff800000007ff00000000ffc00000003ff800000007ff_cppui256;
+  x = (x | x >> 32) &
+      0xfffff80000000000000007ffffc0000000000000003fffff_cppui256;
+  x = (x | x >> 64) &
+      0xfffff800000000000000000000000000000007ffffffffff_cppui256;
+  x = (x | x >> 128) & 0xffffffffffffffff_cppui256;
+  return (uint64_t)x;
+}
+
 /**
  * Interleaves an integer coordinate.
  *

--- a/src/benchmark/BitInterleaving256bitBenchmark.cpp
+++ b/src/benchmark/BitInterleaving256bitBenchmark.cpp
@@ -1,0 +1,39 @@
+#include <benchmark/benchmark.h>
+
+#include "BitInterleaving.h"
+
+static void BM_Interleave_4_64_256_Boost(benchmark::State &state) {
+  IntArray<4, uint64_t> data;
+  uint256_t z;
+  for (auto _ : state) {
+    z = interleave<4, uint64_t, uint256_t>(data);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(z);
+  }
+}
+BENCHMARK(BM_Interleave_4_64_256_Boost);
+
+static void BM_Deinterleave_4_64_256_Boost(benchmark::State &state) {
+  IntArray<4, uint64_t> data;
+  uint256_t z;
+  for (auto _ : state) {
+    data = deinterleave<4, uint64_t, uint256_t>(z);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(z);
+  }
+}
+BENCHMARK(BM_Deinterleave_4_64_256_Boost);
+
+static void BM_RoundTrip_4_64_256_Boost(benchmark::State &state) {
+  IntArray<4, uint64_t> data;
+  uint256_t z;
+  for (auto _ : state) {
+    z = interleave<4, uint64_t, uint256_t>(data);
+    data = deinterleave<4, uint64_t, uint256_t>(z);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(z);
+  }
+}
+BENCHMARK(BM_RoundTrip_4_64_256_Boost);
+
+BENCHMARK_MAIN();

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(BENCHMARKS
   BitInterleaving128bitBenchmark
+  BitInterleaving256bitBenchmark
   BitInterleaving64bitBenchmark
   CoordinateConversionBenchmark
   EventCreationBenchmark

--- a/src/test/BitInterleaving128BitTest.cpp
+++ b/src/test/BitInterleaving128BitTest.cpp
@@ -7,99 +7,58 @@
 #include "BitInterleaving.h"
 #include "BitInterleaving128bit.h"
 
-TEST(BitInterleaving128BitTest, Interleave_4_32_128) {
-  const uint32_t a =
-      bit_string_to_int<uint32_t>("10101010101010101010101010101010");
-  const uint32_t b =
-      bit_string_to_int<uint32_t>("00000000000000001111111111111111");
-  const uint32_t c =
-      bit_string_to_int<uint32_t>("11111111111111110000000000000000");
-  const uint32_t d =
-      bit_string_to_int<uint32_t>("00000000111111111111111100000000");
+const uint32_t integerA =
+    bit_string_to_int<uint32_t>("10101010101010101010101010101010");
+const uint32_t integerB =
+    bit_string_to_int<uint32_t>("00000000000000001111111111111111");
+const uint32_t integerC =
+    bit_string_to_int<uint32_t>("11111111111111110000000000000000");
+const uint32_t integerD =
+    bit_string_to_int<uint32_t>("00000000111111111111111100000000");
 
+const uint64_t interleavedMsb = bit_string_to_int<uint64_t>(
+    "0101010001010100010101000101010011011100110111001101110011011100");
+const uint64_t interleavedLsb = bit_string_to_int<uint64_t>(
+    "1011101010111010101110101011101000110010001100100011001000110010");
+
+TEST(BitInterleaving128BitTest, Interleave_4_32_128) {
   uint64_t msb(0);
   uint64_t lsb(0);
 
-  Interleave_4_32_128(msb, lsb, a, b, c, d);
+  Interleave_4_32_128(msb, lsb, integerA, integerB, integerC, integerD);
 
-  const uint64_t expectedMsb = bit_string_to_int<uint64_t>(
-      "0101010001010100010101000101010011011100110111001101110011011100");
-  const uint64_t expectedLsb = bit_string_to_int<uint64_t>(
-      "1011101010111010101110101011101000110010001100100011001000110010");
-
-  EXPECT_EQ(expectedMsb, msb);
-  EXPECT_EQ(expectedLsb, lsb);
+  EXPECT_EQ(interleavedMsb, msb);
+  EXPECT_EQ(interleavedLsb, lsb);
 }
 
 TEST(BitInterleaving128BitTest, Deinterleave_4_32_128) {
-  const uint64_t msb = bit_string_to_int<uint64_t>(
-      "0101010001010100010101000101010011011100110111001101110011011100");
-  const uint64_t lsb = bit_string_to_int<uint64_t>(
-      "1011101010111010101110101011101000110010001100100011001000110010");
-
   uint32_t a(0), b(0), c(0), d(0);
-  Deinterleave_4_32_128(msb, lsb, a, b, c, d);
+  Deinterleave_4_32_128(interleavedMsb, interleavedLsb, a, b, c, d);
 
-  const uint32_t expectedA =
-      bit_string_to_int<uint32_t>("10101010101010101010101010101010");
-  const uint32_t expectedB =
-      bit_string_to_int<uint32_t>("00000000000000001111111111111111");
-  const uint32_t expectedC =
-      bit_string_to_int<uint32_t>("11111111111111110000000000000000");
-  const uint32_t expectedD =
-      bit_string_to_int<uint32_t>("00000000111111111111111100000000");
-
-  EXPECT_EQ(expectedA, a);
-  EXPECT_EQ(expectedB, b);
-  EXPECT_EQ(expectedC, c);
-  EXPECT_EQ(expectedD, d);
+  EXPECT_EQ(integerA, a);
+  EXPECT_EQ(integerB, b);
+  EXPECT_EQ(integerC, c);
+  EXPECT_EQ(integerD, d);
 }
 
 TEST(BitInterleaving128BitTest, Interleave_4_32_128_Boost) {
-  const uint128_t msb = bit_string_to_int<uint64_t>(
-      "0101010001010100010101000101010011011100110111001101110011011100");
-  const uint128_t lsb = bit_string_to_int<uint64_t>(
-      "1011101010111010101110101011101000110010001100100011001000110010");
+  uint128_t res = interleave<4, uint32_t, uint128_t>(
+      {integerA, integerB, integerC, integerD});
 
-  const uint32_t a =
-      bit_string_to_int<uint32_t>("10101010101010101010101010101010");
-  const uint32_t b =
-      bit_string_to_int<uint32_t>("00000000000000001111111111111111");
-  const uint32_t c =
-      bit_string_to_int<uint32_t>("11111111111111110000000000000000");
-  const uint32_t d =
-      bit_string_to_int<uint32_t>("00000000111111111111111100000000");
+  uint128_t interleaved(interleavedLsb);
+  interleaved |= ((uint128_t)interleavedMsb) << 64;
 
-  uint128_t res = interleave<4, uint32_t, uint128_t>({a, b, c, d});
-
-  uint128_t expected(lsb);
-  expected |= msb << 64;
-
-  EXPECT_EQ(expected, res);
+  EXPECT_EQ(interleaved, res);
 }
 
 TEST(BitInterleaving128BitTest, Deinterleave_4_32_128_Boost) {
-  const uint128_t msb = bit_string_to_int<uint64_t>(
-      "0101010001010100010101000101010011011100110111001101110011011100");
-  const uint128_t lsb = bit_string_to_int<uint64_t>(
-      "1011101010111010101110101011101000110010001100100011001000110010");
-
-  uint128_t z(lsb);
-  z |= msb << 64;
+  uint128_t z(interleavedLsb);
+  z |= ((uint128_t)interleavedMsb) << 64;
 
   const auto result = deinterleave<4, uint32_t, uint128_t>(z);
 
-  const uint32_t expectedA =
-      bit_string_to_int<uint32_t>("10101010101010101010101010101010");
-  const uint32_t expectedB =
-      bit_string_to_int<uint32_t>("00000000000000001111111111111111");
-  const uint32_t expectedC =
-      bit_string_to_int<uint32_t>("11111111111111110000000000000000");
-  const uint32_t expectedD =
-      bit_string_to_int<uint32_t>("00000000111111111111111100000000");
-
-  EXPECT_EQ(expectedA, result[0]);
-  EXPECT_EQ(expectedB, result[1]);
-  EXPECT_EQ(expectedC, result[2]);
-  EXPECT_EQ(expectedD, result[3]);
+  EXPECT_EQ(integerA, result[0]);
+  EXPECT_EQ(integerB, result[1]);
+  EXPECT_EQ(integerC, result[2]);
+  EXPECT_EQ(integerD, result[3]);
 }

--- a/src/test/BitInterleaving256BitTest.cpp
+++ b/src/test/BitInterleaving256BitTest.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include "TestUtil.h"
+
+#include "BitInterleaving.h"
+
+const uint64_t integerA = bit_string_to_int<uint64_t>(
+    "1010101010101010101010101010101010101010101010101010101010101010");
+const uint64_t integerB = bit_string_to_int<uint64_t>(
+    "0000000000000000000000000000000011111111111111111111111111111111");
+const uint64_t integerC = bit_string_to_int<uint64_t>(
+    "1111111111111111111111111111111100000000000000000000000000000000");
+const uint64_t integerD = bit_string_to_int<uint64_t>(
+    "0000000000000000111111111111111111111111111111110000000000000000");
+
+const uint256_t interleavedBitsD = bit_string_to_int<uint64_t>(
+    "0101010001010100010101000101010001010100010101000101010001010100");
+const uint256_t interleavedBitsC = bit_string_to_int<uint64_t>(
+    "1101110011011100110111001101110011011100110111001101110011011100");
+const uint256_t interleavedBitsB = bit_string_to_int<uint64_t>(
+    "1011101010111010101110101011101010111010101110101011101010111010");
+const uint256_t interleavedBitsA = bit_string_to_int<uint64_t>(
+    "0011001000110010001100100011001000110010001100100011001000110010");
+
+TEST(BitInterleaving256BitTest, Interleave_4_64_256_Boost) {
+
+  uint256_t res = interleave<4, uint64_t, uint256_t>(
+      {integerA, integerB, integerC, integerD});
+
+  uint256_t expected(interleavedBitsA);
+  expected |= interleavedBitsB << 64;
+  expected |= interleavedBitsC << 128;
+  expected |= interleavedBitsD << 192;
+
+  EXPECT_EQ(expected, res);
+}
+
+TEST(BitInterleaving256BitTest, Deinterleave_4_64_256_Boost) {
+  uint256_t z(interleavedBitsA);
+  z |= interleavedBitsB << 64;
+  z |= interleavedBitsC << 128;
+  z |= interleavedBitsD << 192;
+
+  const auto result = deinterleave<4, uint64_t, uint256_t>(z);
+
+  EXPECT_EQ(integerA, result[0]);
+  EXPECT_EQ(integerB, result[1]);
+  EXPECT_EQ(integerC, result[2]);
+  EXPECT_EQ(integerD, result[3]);
+}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UNIT_TESTS
   BitInterleaving128BitTest
+  BitInterleaving256BitTest
   BitInterleavingEigenTest
   BitInterleavingTest
   CoordinateConversionTest


### PR DESCRIPTION
Adds 256 bit integer interleaving using Boost's cppint, very similar to the implementation for 128 bit integers.