### PR TITLE
Apply stricter type checking to bit interleaving

### DIFF
--- a/src/BitInterleaving.h
+++ b/src/BitInterleaving.h
@@ -7,33 +7,39 @@
 
 #pragma once
 
+/**
+ * Pad an integer with a given number of padding bits.
+ *
+ * @param N Number of padding bits to add
+ * @param IntT Integer type
+ * @param MortonT Padded integer type
+ * @param x Integer to pad
+ * @return Padded integer
+ */
+template <size_t N, typename IntT, typename MortonT> MortonT pad(IntT x) {
+  throw std::runtime_error("No pad() specialisation.");
+}
+
+/**
+ * Compacts (removes padding from) an integer with a given number of padding
+ * bits.
+ *
+ * @param N Number of padding bits to remove
+ * @param IntT Integer type
+ * @param MortonT Padded integer type
+ * @param x Padded integer
+ * @return Original integer
+ */
+template <size_t N, typename IntT, typename MortonT> IntT compact(MortonT x) {
+  throw std::runtime_error("No compact() specialisation.");
+}
+
 /* Bit masks used for pad and compact operations are derived using
  * docs/bit_padding_generator.py. */
 /* For more details see docs/bit_interleaving.md. */
 
-template <size_t N, typename Int> Int pad(Int x) {
-  throw std::runtime_error("No pad() specialisation.");
-}
-
-template <size_t N, typename Int> Int compact(Int x) {
-  throw std::runtime_error("No compact() specialisation.");
-}
-
-/**
- * Trait used to determine which pad and compact function we can use for a given
- * Morton number type (defaults to the Morton number type itself).
- */
-template <typename T> struct morton_to_pad_compact_int { typedef T type; };
-
-template <> struct morton_to_pad_compact_int<uint32_t> {
-  typedef uint64_t type;
-};
-
-/**
- * Pad an integer with 1 padding bit between integer bits.
- * Maximum input width is 16 bit.
- */
-template <> uint64_t pad<1, uint64_t>(uint64_t x) {
+template <> uint32_t pad<1, uint16_t, uint32_t>(uint16_t v) {
+  uint32_t x(v);
   x &= 0xffff;
   x = (x | x << 8) & 0xff00ff;
   x = (x | x << 4) & 0xf0f0f0f;
@@ -42,25 +48,36 @@ template <> uint64_t pad<1, uint64_t>(uint64_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 1 padding bit between integer
- * bits.
- * Maximum output bit width is 16 bit.
- */
-template <> uint64_t compact<1, uint64_t>(uint64_t x) {
+template <> uint16_t compact<1, uint16_t, uint32_t>(uint32_t x) {
   x &= 0x55555555;
   x = (x | x >> 1) & 0x33333333;
   x = (x | x >> 2) & 0xf0f0f0f;
   x = (x | x >> 4) & 0xff00ff;
   x = (x | x >> 8) & 0xffff;
+  return (uint16_t)x;
+}
+
+template <> uint64_t pad<1, uint16_t, uint64_t>(uint16_t v) {
+  uint64_t x(v);
+  x &= 0xffff;
+  x = (x | x << 8) & 0xff00ff;
+  x = (x | x << 4) & 0xf0f0f0f;
+  x = (x | x << 2) & 0x33333333;
+  x = (x | x << 1) & 0x55555555;
   return x;
 }
 
-/**
- * Pad an integer with 2 padding bits between integer bits.
- * Maximum input width is 16 bit.
- */
-template <> uint64_t pad<2, uint64_t>(uint64_t x) {
+template <> uint16_t compact<1, uint16_t, uint64_t>(uint64_t x) {
+  x &= 0x55555555;
+  x = (x | x >> 1) & 0x33333333;
+  x = (x | x >> 2) & 0xf0f0f0f;
+  x = (x | x >> 4) & 0xff00ff;
+  x = (x | x >> 8) & 0xffff;
+  return (uint16_t)x;
+}
+
+template <> uint64_t pad<2, uint16_t, uint64_t>(uint16_t v) {
+  uint64_t x(v);
   x &= 0xffff;
   x = (x | x << 16) & 0xff0000ff;
   x = (x | x << 8) & 0xf00f00f00f;
@@ -69,25 +86,17 @@ template <> uint64_t pad<2, uint64_t>(uint64_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 3 padding bit between integer
- * bits.
- * Maximum output bit width is 16 bit.
- */
-template <> uint64_t compact<2, uint64_t>(uint64_t x) {
+template <> uint16_t compact<2, uint16_t, uint64_t>(uint64_t x) {
   x &= 0x249249249249;
   x = (x | x >> 2) & 0xc30c30c30c3;
   x = (x | x >> 4) & 0xf00f00f00f;
   x = (x | x >> 8) & 0xff0000ff;
   x = (x | x >> 16) & 0xffff;
-  return x;
+  return (uint16_t)x;
 }
 
-/**
- * Pad an integer with 3 padding bits between integer bits.
- * Maximum input width is 16 bit.
- */
-template <> uint64_t pad<3, uint64_t>(uint64_t x) {
+template <> uint64_t pad<3, uint16_t, uint64_t>(uint16_t v) {
+  uint64_t x(v);
   x &= 0xffff;
   x = (x | x << 32) & 0xf800000007ff;
   x = (x | x << 16) & 0xf80007c0003f;
@@ -98,12 +107,7 @@ template <> uint64_t pad<3, uint64_t>(uint64_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 3 padding bit between integer
- * bits.
- * Maximum output bit width is 16 bit.
- */
-template <> uint64_t compact<3, uint64_t>(uint64_t x) {
+template <> uint16_t compact<3, uint16_t, uint64_t>(uint64_t x) {
   x &= 0x1111111111111111;
   x = (x | x >> 1) & 0x909090909090909;
   x = (x | x >> 2) & 0x843084308430843;
@@ -111,17 +115,14 @@ template <> uint64_t compact<3, uint64_t>(uint64_t x) {
   x = (x | x >> 8) & 0xf80007c0003f;
   x = (x | x >> 16) & 0xf800000007ff;
   x = (x | x >> 32) & 0xffff;
-  return x;
+  return (uint16_t)x;
 }
 
 using uint128_t = boost::multiprecision::uint128_t;
 
-/**
- * Pad an integer with 1 padding bit between integer bits.
- * Maximum input width is 32 bit.
- */
-template <> uint128_t pad<1, uint128_t>(uint128_t x) {
+template <> uint128_t pad<1, uint32_t, uint128_t>(uint32_t v) {
   using namespace boost::multiprecision::literals;
+  uint128_t x(v);
   x &= 0xffffffff_cppui128;
   x = (x | x << 16) & 0xffff0000ffff_cppui128;
   x = (x | x << 8) & 0xff00ff00ff00ff_cppui128;
@@ -131,12 +132,7 @@ template <> uint128_t pad<1, uint128_t>(uint128_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 1 padding bit between integer
- * bits.
- * Maximum output bit width is 32 bit.
- */
-template <> uint128_t compact<1, uint128_t>(uint128_t x) {
+template <> uint32_t compact<1, uint32_t, uint128_t>(uint128_t x) {
   using namespace boost::multiprecision::literals;
   x &= 0x5555555555555555_cppui128;
   x = (x | x >> 1) & 0x3333333333333333_cppui128;
@@ -144,15 +140,12 @@ template <> uint128_t compact<1, uint128_t>(uint128_t x) {
   x = (x | x >> 4) & 0xff00ff00ff00ff_cppui128;
   x = (x | x >> 8) & 0xffff0000ffff_cppui128;
   x = (x | x >> 16) & 0xffffffff_cppui128;
-  return x;
+  return (uint32_t)x;
 }
 
-/**
- * Pad an integer with 2 padding bits between integer bits.
- * Maximum input width is 32 bit.
- */
-template <> uint128_t pad<2, uint128_t>(uint128_t x) {
+template <> uint128_t pad<2, uint32_t, uint128_t>(uint32_t v) {
   using namespace boost::multiprecision::literals;
+  uint128_t x(v);
   x &= 0xffffffff_cppui128;
   x = (x | x << 32) & 0xffff00000000ffff_cppui128;
   x = (x | x << 16) & 0xff0000ff0000ff0000ff_cppui128;
@@ -162,12 +155,7 @@ template <> uint128_t pad<2, uint128_t>(uint128_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 2 padding bits between integer
- * bits.
- * Maximum output bit width is 32 bit.
- */
-template <> uint128_t compact<2, uint128_t>(uint128_t x) {
+template <> uint32_t compact<2, uint32_t, uint128_t>(uint128_t x) {
   using namespace boost::multiprecision::literals;
   x &= 0x249249249249249249249249_cppui128;
   x = (x | x >> 2) & 0xc30c30c30c30c30c30c30c3_cppui128;
@@ -175,15 +163,12 @@ template <> uint128_t compact<2, uint128_t>(uint128_t x) {
   x = (x | x >> 8) & 0xff0000ff0000ff0000ff_cppui128;
   x = (x | x >> 16) & 0xffff00000000ffff_cppui128;
   x = (x | x >> 32) & 0xffffffff_cppui128;
-  return x;
+  return (uint32_t)x;
 }
 
-/**
- * Pad an integer with 3 padding bits between integer bits.
- * Maximum input width is 32 bit.
- */
-template <> uint128_t pad<3, uint128_t>(uint128_t x) {
+template <> uint128_t pad<3, uint32_t, uint128_t>(uint32_t v) {
   using namespace boost::multiprecision::literals;
+  uint128_t x(v);
   x &= 0xffffffff_cppui128;
   x = (x | x << 64) & 0xffc0000000000000003fffff_cppui128;
   x = (x | x << 32) & 0xffc00000003ff800000007ff_cppui128;
@@ -195,12 +180,7 @@ template <> uint128_t pad<3, uint128_t>(uint128_t x) {
   return x;
 }
 
-/**
- * Compacts (removes padding) an integer with 3 padding bits between integer
- * bits.
- * Maximum output bit width is 32 bit.
- */
-template <> uint128_t compact<3, uint128_t>(uint128_t x) {
+template <> uint32_t compact<3, uint32_t, uint128_t>(uint128_t x) {
   using namespace boost::multiprecision::literals;
   x &= 0x11111111111111111111111111111111_cppui128;
   x = (x | x >> 1) & 0x9090909090909090909090909090909_cppui128;
@@ -210,27 +190,41 @@ template <> uint128_t compact<3, uint128_t>(uint128_t x) {
   x = (x | x >> 16) & 0xffc00000003ff800000007ff_cppui128;
   x = (x | x >> 32) & 0xffc0000000000000003fffff_cppui128;
   x = (x | x >> 64) & 0xffffffff_cppui128;
-  return x;
+  return (uint32_t)x;
 }
 
+/**
+ * Interleaves an integer coordinate.
+ *
+ * @param ND Number of dimensions
+ * @param IntT Intermediate integer type
+ * @param MortonT Morton number type
+ * @param coord Coordinate in intermediate integer space
+ * @return Interleaved integer (Morton number)
+ */
 template <size_t ND, typename IntT, typename MortonT>
 MortonT interleave(const IntArray<ND, IntT> &coord) {
   MortonT retVal(0);
   for (size_t i = 0; i < ND; i++) {
-    retVal |=
-        pad<ND - 1, typename morton_to_pad_compact_int<MortonT>::type>(coord[i])
-        << i;
+    retVal |= pad<ND - 1, IntT, MortonT>(coord[i]) << i;
   }
   return retVal;
 }
 
+/**
+ * Deinterleaves a Morton number into an integer coordinate.
+ *
+ * @param ND Number of dimensions
+ * @param IntT Intermediate integer type
+ * @param MortonT Morton number type
+ * @param z Morton number
+ * @return Integer coordinate
+ */
 template <size_t ND, typename IntT, typename MortonT>
 IntArray<ND, IntT> deinterleave(const MortonT z) {
   IntArray<ND, IntT> retVal;
   for (size_t i = 0; i < ND; i++) {
-    retVal[i] = (IntT)
-        compact<ND - 1, typename morton_to_pad_compact_int<MortonT>::type>(z >>
-                                                                           i);
+    retVal[i] = (IntT)compact<ND - 1, IntT, MortonT>(z >> i);
   }
   return retVal;
 }


### PR DESCRIPTION
Ensures that the selected interleaving/deinterleaving is valid by adding input integer type to `pad()` and `compact()` functions.

This was an issue if you requested interleaving of an integer type and the only `pad()`/`compact()` implementations were for smaller intermediate integer types.

Also tidies up documentation in `BitInterleaving.h`.