### PR TITLE
Try improving convert_events performance.

### DIFF
--- a/src/EventToMDEventConversion.h
+++ b/src/EventToMDEventConversion.h
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <tuple>
 #include <vector>
 
@@ -107,7 +108,8 @@ void convert_events(std::vector<MDEvent<3, IntT, MortonT>> &mdEvents,
       }
     }
 
-    if (mdEventsForSpectrum.size() == 4 * 1024) {
+    if (mdEventsForSpectrum.size() >=
+        std::max(mdEventsForSpectrum.capacity() / 2, 4 * 1024)) {
 #pragma omp critical
       {
         /* Add to event list */


### PR DESCRIPTION
@DanNixon Yesterday @igudich pointed out to me that `convert_events` might not parallelize well due to the `#pragma omp critical` in `convert_events`. I had this quick idea of improving it.

Since I cannot get the conan config to work on Ubuntu, I could not try this myself. Could you give it a try please?

You may try to adjust the size threshold.